### PR TITLE
Use GraphQL.Client for Scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+**/.DS_Store

--- a/src/GraphQLinq.Scaffolding/MySerializer.cs
+++ b/src/GraphQLinq.Scaffolding/MySerializer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Client.Abstractions;
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Serializer.Newtonsoft;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Scaffolding;
+
+public class MySerializer : IGraphQLWebsocketJsonSerializer
+{
+    public static JsonSerializerSettings DefaultJsonSerializerSettings => new JsonSerializerSettings
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver { IgnoreIsSpecifiedMembers = true },
+        MissingMemberHandling = MissingMemberHandling.Ignore,
+        Converters = { new ConstantCaseEnumConverter() }
+    };
+
+    public JsonSerializerSettings JsonSerializerSettings { get; }
+
+    public MySerializer() : this(DefaultJsonSerializerSettings) { }
+
+    public MySerializer(Action<JsonSerializerSettings> configure) : this(configure.AndReturn(DefaultJsonSerializerSettings)) { }
+
+    public MySerializer(JsonSerializerSettings jsonSerializerSettings)
+    {
+        JsonSerializerSettings = jsonSerializerSettings;
+        ConfigureMandatorySerializerOptions();
+    }
+
+    // deserialize extensions to Dictionary<string, object>
+    private void ConfigureMandatorySerializerOptions() => JsonSerializerSettings.Converters.Insert(0, new MapConverter());
+
+    public string SerializeToString(GraphQLRequest request) => JsonConvert.SerializeObject(request, JsonSerializerSettings);
+
+    public byte[] SerializeToBytes(GraphQLWebSocketRequest request)
+    {
+        var json = JsonConvert.SerializeObject(request, JsonSerializerSettings);
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream) => DeserializeFromUtf8Stream<WebsocketMessageWrapper>(stream);
+
+    public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes) =>
+        JsonConvert.DeserializeObject<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(Encoding.UTF8.GetString(bytes),
+            JsonSerializerSettings);
+
+    public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken) => DeserializeFromUtf8Stream<GraphQLResponse<TResponse>>(stream);
+
+    private Task<T> DeserializeFromUtf8Stream<T>(Stream stream)
+    {
+        using var sr = new StreamReader(stream);
+        using JsonReader reader = new JsonTextReader(sr);
+        var serializer = JsonSerializer.Create(JsonSerializerSettings);
+        return Task.FromResult(serializer.Deserialize<T>(reader));
+    }
+}

--- a/src/GraphQLinq.Scaffolding/Program.cs
+++ b/src/GraphQLinq.Scaffolding/Program.cs
@@ -6,6 +6,10 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.Newtonsoft;
+using Scaffolding;
 using Spectre.Console;
 
 namespace GraphQLinq.Scaffolding
@@ -135,15 +139,31 @@ namespace GraphQLinq.Scaffolding
 
             AnsiConsole.MarkupLine("Scaffolding GraphQL client code for [bold]{0}[/] to [bold]{1}[/]", endpoint, outputFolder);
 
-            var schema = await AnsiConsole.Status().StartAsync("Performing introspection", async ctx =>
+            var data = await AnsiConsole.Status().StartAsync("Performing introspection", async ctx =>
             {
-                AnsiConsole.WriteLine("Running introspection query ...");
-                using var httpClient = new HttpClient();
-                using var responseMessage = await httpClient.PostAsJsonAsync(endpoint, new { query = IntrospectionQuery });
+                try
+                {
 
-                AnsiConsole.WriteLine("Reading and deserializing schema information ...");
-                var schemaJson = await responseMessage.Content.ReadAsStringAsync();
-                return JsonSerializer.Deserialize<RootSchemaObject>(schemaJson, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                    AnsiConsole.WriteLine("Running introspection query ...");
+                    //using var httpClient = new HttpClient();
+                    GraphQLHttpClient client = new GraphQLHttpClient(endpoint, new MySerializer());
+                    var request = new GraphQLRequest
+                    {
+                        Query = IntrospectionQuery
+                    };
+                    var responseMessage = await client.SendQueryAsync<Data>(request);
+                    //using var responseMessage = await httpClient.GetAsync(endpoint.ToString(), JsonContent.Create(new { query = IntrospectionQuery }));
+                    //using var responseMessage = await httpClient.PostAsJsonAsync(endpoint, new { query = IntrospectionQuery });
+
+                    AnsiConsole.WriteLine("Reading and deserializing schema information ...");
+                    return responseMessage.Data;
+                    //var schemaJson = await responseMessage;
+                    //return JsonSerializer.Deserialize<RootSchemaObject>(schemaJson, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
             });
             AnsiConsole.WriteLine();
 
@@ -158,7 +178,7 @@ namespace GraphQLinq.Scaffolding
                 };
 
                 var graphQLClassesGenerator = new GraphQLClassesGenerator(codeGenerationOptions);
-                return graphQLClassesGenerator.GenerateClient(schema.Data.Schema, endpoint.AbsoluteUri);
+                return graphQLClassesGenerator.GenerateClient(data.Schema, endpoint.AbsoluteUri);
             });
 
             AnsiConsole.WriteLine();

--- a/src/GraphQLinq.Scaffolding/RootSchemaObject.cs
+++ b/src/GraphQLinq.Scaffolding/RootSchemaObject.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace GraphQLinq.Scaffolding
 {
@@ -12,7 +12,7 @@ namespace GraphQLinq.Scaffolding
 
     public class Data
     {
-        [JsonPropertyName("__schema")]
+        [JsonProperty("__schema")]
         public Schema Schema { get; set; }
     }
 
@@ -33,7 +33,7 @@ namespace GraphQLinq.Scaffolding
         public List<GraphqlType> Interfaces { get; set; }
     }
 
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    //[JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum TypeKind
     {
         List,

--- a/src/GraphQLinq.Scaffolding/Scaffolding.csproj
+++ b/src/GraphQLinq.Scaffolding/Scaffolding.csproj
@@ -31,6 +31,10 @@
     <Description>Generate classes from GraphQL endpoint and write strongly typed queries with LINQ.</Description>
     <PackageId>GraphQLinq.Scaffolding</PackageId>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <WarningLevel>4</WarningLevel>
+    <AssemblyName>GraphQLinq.Scaffolding</AssemblyName>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
@@ -38,6 +42,12 @@
     <PackageReference Include="Spectre.Console" Version="0.38.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="GraphQL.Client" Version="5.1.0" />
+    <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="GraphQL.Client" />
+    <None Remove="GraphQL.Client.Serializer.Newtonsoft" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\docs\Images\Icon.png">

--- a/src/GraphQLinq.TestServer/Properties/launchSettings.json
+++ b/src/GraphQLinq.TestServer/Properties/launchSettings.json
@@ -1,8 +1,7 @@
-﻿{
+{
   "profiles": {
     "GraphQLing.TestServer": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/GraphQLinq.TestServer/TestServer.csproj
+++ b/src/GraphQLinq.TestServer/TestServer.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'GraphQLing.TestServer' " />
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage"></AssemblyAttribute>
   </ItemGroup>


### PR DESCRIPTION
Using GraphQL improves performance and interaction with GraphQL client. Specifically, this was tested using the SpaceX sample but did't work with the Lens API GraphQL. Using GraphQL.Client got rid of the issue and works on both.
